### PR TITLE
`ClassName::fromString()`: trim leading namespace separator

### DIFF
--- a/lib/Domain/ClassName.php
+++ b/lib/Domain/ClassName.php
@@ -22,7 +22,7 @@ final class ClassName
     public static function fromString(string $string): self
     {
         $new = new self();
-        $new->fullyQualifiedName = $string;
+        $new->fullyQualifiedName = ltrim($string, self::DEFAULT_NAMESPACE_SEPARATOR);
 
         return $new;
     }

--- a/tests/Integration/Simple/SimpleClassToFileTest.php
+++ b/tests/Integration/Simple/SimpleClassToFileTest.php
@@ -30,6 +30,15 @@ class SimpleClassToFileTest extends SimpleTestCase
         ]), $candidates);
     }
 
+    public function testAbsoluteClassNameToFile(): void
+    {
+        $candidates = $this->classToFile->classToFileCandidates(ClassName::fromString('\\Acme\\Foobar'));
+
+        $this->assertEquals(FilePathCandidates::fromFilePaths([
+            FilePath::fromString(__DIR__ . '/../../Workspace/lib/Foobar.php')
+        ]), $candidates);
+    }
+
     public function testClassToFileInvalid(): void
     {
         $candidates = $this->classToFile->classToFileCandidates(

--- a/tests/Unit/ClassNameTest.php
+++ b/tests/Unit/ClassNameTest.php
@@ -25,6 +25,11 @@ class ClassNameTest extends TestCase
                 true,
             ],
             [
+                '\\Foobar\\BarFoo',
+                'Foobar\\BarFoo',
+                true,
+            ],
+            [
                 'Foobar\\BarFoo',
                 'Foobar\\BarFoo',
                 true,


### PR DESCRIPTION
In phpactor it can help to move classes between namespaces