### PR TITLE
Fix case where installed path is symlink

### DIFF
--- a/lib/Adapter/Composer/ComposerFileToClass.php
+++ b/lib/Adapter/Composer/ComposerFileToClass.php
@@ -77,11 +77,11 @@ final class ComposerFileToClass implements FileToClass
             $pathPrefixes = (array) $pathPrefixes;
 
             // remove any relativeness from the paths
-            //
-            // TODO: realpath will return void if the path does not exist
-            //       we should not depend on the file path existing.
+            // we should not depend on the file path existing.
             $pathPrefixes = array_map(function ($pathPrefix) {
-                return Path::canonicalize($pathPrefix);
+                $canonicalizedPath = Path::canonicalize($pathPrefix);
+                $realPath = realpath($canonicalizedPath);
+                return $realPath ?: $canonicalizedPath;
             }, $pathPrefixes);
 
             foreach ($pathPrefixes as $pathPrefix) {

--- a/tests/Integration/Composer/ComposerFileToClassTest.php
+++ b/tests/Integration/Composer/ComposerFileToClassTest.php
@@ -36,6 +36,15 @@ class ComposerFileToClassTest extends ComposerTestCase
     }
 
     /**
+     * @testdox PSR-4 file with symlinked path components
+     */
+    public function testPsr4Symlinked(): void
+    {
+        $this->loadExample('psr4-symlinked-project.json');
+        $this->assertFilePathToClassName('/symlinked-package/Class.php', ['Acme\\Test\\Class']);
+    }
+
+    /**
      * @testdox PSR-4 multiple matching prefixes
      */
     public function testPsr4MultipleMatches(): void

--- a/tests/Integration/Composer/composers/psr4-symlinked-project.json
+++ b/tests/Integration/Composer/composers/psr4-symlinked-project.json
@@ -1,0 +1,18 @@
+{
+    "name": "dantleech/basic",
+    "authors": [
+        {
+            "name": "dantleech",
+            "email": "dan.t.leech@gmail.com"
+        }
+    ],
+    "repositories": [
+        {
+            "type": "path",
+            "url": "./*"
+        }
+    ],
+    "require": {
+        "dantleech/symlinked": "1.0.0"
+    }
+}

--- a/tests/Integration/Composer/project/symlinked-package/Class.php
+++ b/tests/Integration/Composer/project/symlinked-package/Class.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Acme\Test;
+
+class Class
+{
+}

--- a/tests/Integration/Composer/project/symlinked-package/composer.json
+++ b/tests/Integration/Composer/project/symlinked-package/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "dantleech/symlinked",
+    "version": "1.0.0",
+    "authors": [
+        {
+            "name": "dantleech",
+            "email": "dan.t.leech@gmail.com"
+        }
+    ],
+    "require": {},
+    "autoload": {
+        "psr-4": {
+            "Acme\\Test\\": "./"
+        }
+    }
+}


### PR DESCRIPTION
One can install packages from a local path via composers repositories type "path".
Those are typically symlinks which were not resolved. We therefore add a realpath() call, but falling back to old behavior if it didn't resolve. That way we keep independent of realpath() as requested by the inline comment.

Resolves: https://github.com/phpactor/phpactor/issues/2727